### PR TITLE
Phase 2: assembly version summary (2.2) + previous-current snapshot (2.1)

### DIFF
--- a/flows/README.md
+++ b/flows/README.md
@@ -132,59 +132,6 @@ This example command assumes the [genomehubs/goat-data](https://github.com/genom
 SKIP_PREFECT=true python3 -m flows.parsers.parse_ncbi_assemblies -i /tmp/assembly-data/ncbi_datasets_canidae.jsonl -y /tmp/assembly-data/ncbi_datasets_eukaryota.types.yaml -a
 ```
 
-### Assembly version tracking
-
-Three flows track NCBI assembly versions that become superseded over time, writing the result to `assembly_historical.tsv`:
-
-- `flows/parsers/parse_backfill_historical_versions.py` — **one-time** backfill. Given a JSONL of current assemblies, finds every assembly with version > 1, discovers its earlier versions over NCBI FTP, and parses each one into `assembly_historical.tsv`. Run once before starting the daily incremental flow below.
-- `flows/parsers/parse_assembly_versions.py` — **daily incremental**. Given today's assembly JSONL and yesterday's parsed `assembly_current.tsv` (kept alongside it as `assembly_current.tsv.previous`), detects any assembly that became superseded since yesterday and appends it to `assembly_historical.tsv`. No NCBI fetches are required — the row is copied from the previous parse. If a predecessor version isn't found in `assembly_current.tsv.previous` (e.g. it was never present in the historical TSV in the first place), the assembly is written to `missing_versions.json` instead of failing.
-- `flows/updaters/update_assembly_versions.py` — updater that consumes `missing_versions.json`, fetches each missing accession's raw NCBI metadata, and writes it to `missing_assembly_versions.jsonl`. Feed that file back into `parse_backfill_historical_versions.py` as its `--input_path` to parse the missing version(s) into `assembly_historical.tsv`.
-
-Only `parse_backfill_historical_versions.py` takes a `--yaml_path`; its output path is resolved relative to the *directory the YAML file lives in*, not `--work_dir`, so place a copy of the YAML in `--work_dir` if you want the TSV written there. `parse_assembly_versions.py` and `update_assembly_versions.py` take no YAML — all paths are derived from `--input_path`/`--work_dir`.
-
-#### Example: minimal end-to-end run
-
-This walkthrough uses the existing test fixture `tests/test_data/assembly_test_sample.jsonl`, which contains three real assemblies, two of them (`GCA_000222935.2` and `GCA_000412225.2`) at version 2 — no extra data needs to be fetched or fabricated to exercise both code paths below.
-
-```
-mkdir -p /tmp/assembly-versions
-cp configs/assembly_historical.types.yaml /tmp/assembly-versions/
-cp tests/test_data/assembly_test_sample.jsonl /tmp/assembly-versions/assembly_data_report.jsonl
-
-# 1. One-time backfill: discovers and parses each assembly's earlier version(s) via NCBI FTP
-SKIP_PREFECT=true python3 -m flows.parsers.parse_backfill_historical_versions \
-  --input_path /tmp/assembly-versions/assembly_data_report.jsonl \
-  --yaml_path /tmp/assembly-versions/assembly_historical.types.yaml \
-  --work_dir /tmp/assembly-versions
-# -> writes /tmp/assembly-versions/assembly_historical.tsv
-
-# 2. Simulate "yesterday's" parse: a current.tsv that only knows about GCA_000222935.1
-printf "accession\tassembly_id\nGCA_000222935.1\tGCA_000222935_1\n" \
-  > /tmp/assembly-versions/assembly_current.tsv.previous
-
-# 3. Daily incremental: compares today's JSONL against yesterday's TSV
-SKIP_PREFECT=true python3 -m flows.parsers.parse_assembly_versions \
-  --input_path /tmp/assembly-versions/assembly_data_report.jsonl
-# -> GCA_000222935.2 supersedes the .1 row above: appended to assembly_historical.tsv
-# -> GCA_000412225.2 and GCA_003706615.3 have no earlier version in
-#    assembly_current.tsv.previous: both written to
-#    /tmp/assembly-versions/missing_versions.json instead
-
-# 4. Updater: fetch raw metadata for the accessions reported as missing
-SKIP_PREFECT=true python3 -m flows.updaters.update_assembly_versions \
-  --missing_json /tmp/assembly-versions/missing_versions.json \
-  --work_dir /tmp/assembly-versions
-# -> writes /tmp/assembly-versions/missing_assembly_versions.jsonl
-
-# 5. Feed the updater's output back into step 1 to backfill the missing version
-SKIP_PREFECT=true python3 -m flows.parsers.parse_backfill_historical_versions \
-  --input_path /tmp/assembly-versions/missing_assembly_versions.jsonl \
-  --yaml_path /tmp/assembly-versions/assembly_historical.types.yaml \
-  --work_dir /tmp/assembly-versions
-```
-
-Steps 1, 4 and 5 fetch from NCBI and require the [`datasets`](https://www.ncbi.nlm.nih.gov/datasets/docs/v2/download-and-install/) CLI on `PATH` plus network access (FTP for version discovery, `datasets summary` for metadata); without it they report a clean per-accession fetch failure rather than crashing. Step 3 (`parse_assembly_versions.py`) makes no network calls at all — it only reads the previous TSV and the new JSONL.
-
 ### Validate
 
 The flow at `flows/lib/validate_file_pair.py` runs [blobtk validate](https://github.com/genomehubs/blobtk/wiki/blobtk-validate) to validate the entries in a TSV file against the YAML configuration and, optionally, an NCBI taxdump format taxonomy.

--- a/flows/lib/generate_assembly_summary.py
+++ b/flows/lib/generate_assembly_summary.py
@@ -1,0 +1,231 @@
+"""Combine current and historical assembly TSVs into a per-base-accession summary.
+
+Reads assembly_current.tsv and assembly_historical.tsv from the working
+directory, computes version history for each base accession (first version
+date, current version date, EBP metric tracking, version gaps), and writes
+assembly_version_summary.tsv.  Emits a completion event so downstream
+Phase 3 taxon milestone flows can be triggered.
+
+Run after parse_assembly_versions completes.
+
+Usage:
+    python -m flows.lib.generate_assembly_summary --work_dir tmp
+"""
+
+import csv
+import os
+from collections import defaultdict
+
+from flows.lib.assembly_versions_utils import parse_accession
+from flows.lib.conditional_import import emit_event, flow
+from flows.lib.shared_args import WORK_DIR
+from flows.lib.shared_args import parse_args as _parse_args
+
+CURRENT_TSV = "assembly_current.tsv"
+HISTORICAL_TSV = "assembly_historical.tsv"
+OUTPUT_TSV = "assembly_version_summary.tsv"
+
+# EBP metric columns to check (either naming convention may appear)
+EBP_METRIC_COLUMNS = {"ebpStandardDate", "ebp_standard_date", "ebpMetricDate", "ebp_metric_date"}
+
+
+def _has_ebp_metric(row: dict) -> bool:
+    """Return True if any EBP metric date column is populated."""
+    return any(row.get(col) for col in EBP_METRIC_COLUMNS)
+
+
+def load_assemblies(current_tsv: str, historical_tsv: str) -> list[dict]:
+    """Load and combine rows from current and historical TSVs.
+
+    Normalises the accession column so downstream code can always use
+    'accession', regardless of which phase wrote the row.
+
+    Args:
+        current_tsv: Path to assembly_current.tsv.
+        historical_tsv: Path to assembly_historical.tsv.
+
+    Returns:
+        List of row dicts with a guaranteed 'accession' key.
+    """
+    rows = []
+
+    for path, label in [(current_tsv, "current"), (historical_tsv, "historical")]:
+        if not os.path.exists(path):
+            print(f"  Warning: {label} TSV not found: {path}")
+            continue
+        count = 0
+        with open(path, encoding="utf-8") as f:
+            for row in csv.DictReader(f, delimiter="\t"):
+                # Normalise to 'accession' so the rest of the code is uniform
+                if "accession" not in row or not row["accession"]:
+                    row["accession"] = row.get("genbankAccession", "")
+                rows.append(row)
+                count += 1
+        print(f"  Loaded {count} {label} rows")
+
+    return rows
+
+
+def find_version_gaps(versions: list[int]) -> str:
+    """Return a comma-separated string of missing version numbers, or ''."""
+    if not versions:
+        return ""
+    expected = set(range(1, max(versions) + 1))
+    missing = sorted(expected - set(versions))
+    return ",".join(str(v) for v in missing)
+
+
+def generate_summary_for_base(base_accession: str, rows: list[dict]) -> dict:
+    """Compute version summary for a single base accession.
+
+    Args:
+        base_accession: Base accession without version suffix (e.g. GCA_000002035).
+        rows: All rows (current + historical) for this base accession,
+            sorted by version number ascending.
+
+    Returns:
+        Summary dict with one entry per output column.
+    """
+    # Sort by version number
+    rows = sorted(rows, key=lambda r: parse_accession(r["accession"])[1])
+
+    versions = [parse_accession(r["accession"])[1] for r in rows]
+    version_gaps = find_version_gaps(versions)
+
+    first_row = rows[0]
+    current_row = rows[-1]
+
+    # versionStatus column may be camelCase (Phase 0 YAML) or snake_case (Phase 1 copy)
+    def version_status(row):
+        return row.get("versionStatus") or row.get("version_status") or "current"
+
+    superseded_count = sum(1 for r in rows if version_status(r) == "superseded")
+
+    # First version that met EBP metric criteria
+    first_ebp_row = next((r for r in rows if _has_ebp_metric(r)), None)
+
+    return {
+        "base_accession": base_accession,
+        "taxId": first_row.get("taxId", ""),
+        "first_version_accession": first_row["accession"],
+        "first_version_number": versions[0],
+        "first_version_date": first_row.get("releaseDate", ""),
+        "current_version_accession": current_row["accession"],
+        "current_version_number": versions[-1],
+        "current_version_date": current_row.get("releaseDate", ""),
+        "total_versions": len(rows),
+        "superseded_versions": superseded_count,
+        "first_ebp_metric_accession": first_ebp_row["accession"] if first_ebp_row else "",
+        "first_ebp_metric_version": parse_accession(first_ebp_row["accession"])[1] if first_ebp_row else "",
+        "first_ebp_metric_date": first_ebp_row.get("releaseDate", "") if first_ebp_row else "",
+        "version_gaps": version_gaps,
+    }
+
+
+SUMMARY_FIELDNAMES = [
+    "base_accession",
+    "taxId",
+    "first_version_accession",
+    "first_version_number",
+    "first_version_date",
+    "current_version_accession",
+    "current_version_number",
+    "current_version_date",
+    "total_versions",
+    "superseded_versions",
+    "first_ebp_metric_accession",
+    "first_ebp_metric_version",
+    "first_ebp_metric_date",
+    "version_gaps",
+]
+
+
+@flow(log_prints=True)
+def generate_assembly_summary(work_dir: str = ".") -> None:
+    """Combine current and historical TSVs into a per-base-accession summary.
+
+    Args:
+        work_dir: Directory containing assembly_current.tsv and
+            assembly_historical.tsv; output is written there too.
+    """
+    current_tsv = os.path.join(work_dir, CURRENT_TSV)
+    historical_tsv = os.path.join(work_dir, HISTORICAL_TSV)
+    output_tsv = os.path.join(work_dir, OUTPUT_TSV)
+
+    separator = "=" * 80
+    print(f"\n{separator}")
+    print("ASSEMBLY VERSION SUMMARY")
+    print(f"{separator}\n")
+
+    print("[1/3] Loading assemblies...")
+    rows = load_assemblies(current_tsv, historical_tsv)
+
+    if not rows:
+        print("  No assembly data found — nothing to summarise.")
+        emit_event(
+            event="generate.assembly_summary.completed",
+            resource={
+                "prefect.resource.id": f"generate.assembly_summary.{work_dir}",
+                "prefect.resource.type": "assembly.summary",
+            },
+            payload={"base_accessions": 0, "status": "no_op"},
+        )
+        return
+
+    print(f"\n[2/3] Generating summaries...")
+    by_base: dict[str, list[dict]] = defaultdict(list)
+    for row in rows:
+        acc = row.get("accession", "")
+        if not acc:
+            continue
+        base_acc, _ = parse_accession(acc)
+        by_base[base_acc].append(row)
+
+    summaries = []
+    for base_acc in sorted(by_base):
+        summaries.append(generate_summary_for_base(base_acc, by_base[base_acc]))
+
+    print(f"  Processed {len(summaries)} unique base accessions")
+
+    print(f"\n[3/3] Writing output...")
+    with open(output_tsv, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=SUMMARY_FIELDNAMES, delimiter="\t")
+        writer.writeheader()
+        writer.writerows(summaries)
+
+    multi_version = sum(1 for s in summaries if s["total_versions"] > 1)
+    with_gaps = sum(1 for s in summaries if s["version_gaps"])
+    with_ebp = sum(1 for s in summaries if s["first_ebp_metric_accession"])
+
+    print(f"\n{separator}")
+    print("ASSEMBLY VERSION SUMMARY COMPLETE")
+    print(f"{separator}")
+    print(f"  Base accessions:          {len(summaries)}")
+    print(f"  Multi-version assemblies: {multi_version}")
+    print(f"  Assemblies with gaps:     {with_gaps}")
+    print(f"  Assemblies with EBP:      {with_ebp}")
+    print(f"  Output:                   {output_tsv}")
+    print(f"{separator}\n")
+
+    emit_event(
+        event="generate.assembly_summary.completed",
+        resource={
+            "prefect.resource.id": f"generate.assembly_summary.{work_dir}",
+            "prefect.resource.type": "assembly.summary",
+        },
+        payload={
+            "base_accessions": len(summaries),
+            "multi_version": multi_version,
+            "with_gaps": with_gaps,
+            "with_ebp": with_ebp,
+            "status": "success",
+        },
+    )
+
+
+if __name__ == "__main__":
+    args = _parse_args(
+        [WORK_DIR],
+        description="Aggregate current and historical assembly TSVs into version summary",
+    )
+    generate_assembly_summary(work_dir=args.work_dir)

--- a/flows/parsers/parse_ncbi_assemblies.py
+++ b/flows/parsers/parse_ncbi_assemblies.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import shutil
 import subprocess
 from collections import defaultdict
 from glob import glob
@@ -155,6 +156,26 @@ def process_assembly_report(
         processed_report["processedAssemblyInfo"]["primaryValue"] = 1
 
     return processed_report
+
+
+def snapshot_previous_output(config: Config) -> None:
+    """Copy the prior-run output TSV to a `.previous` sibling before it is overwritten.
+
+    parse_assembly_versions needs yesterday's assembly_current.tsv to find each newly
+    superseded predecessor (v_n-1), but write_to_tsv overwrites the output file in
+    place. fetch_previous_file_pair has already placed yesterday's published copy at
+    config.meta["file_name"], so snapshotting it here preserves it across the overwrite,
+    at the exact path the historical parser reads. No-op on the first run, when no prior
+    output exists.
+
+    Args:
+        config (Config): Config whose meta["file_name"] is the output TSV path.
+    """
+    output_path = config.meta.get("file_name")
+    if output_path and os.path.exists(output_path):
+        previous_path = f"{output_path}.previous"
+        shutil.copy2(output_path, previous_path)
+        print(f"  Snapshotted previous output -> {previous_path}")
 
 
 @task()
@@ -550,6 +571,7 @@ def parse_ncbi_assemblies(
     else:
         data_freeze = parse_data_freeze_file(data_freeze_path)  # This returns the data freeze dictionary
         process_datafreeze_info(parsed, data_freeze, config)
+    snapshot_previous_output(config)
     write_to_tsv(parsed, config)
 
 

--- a/tests/README_phase_0_backfill.md
+++ b/tests/README_phase_0_backfill.md
@@ -1,0 +1,86 @@
+# Phase 0: Testing Guide for Historical Assembly Backfill
+
+This guide explains how to run and test the one-time historical backfill
+implementation (`parse_backfill_historical_versions.py`).
+
+## Prerequisites
+
+### 1. Install Dependencies
+
+```bash
+# Recommended: use the project conda environment
+conda env create -f env.yaml
+conda activate genomehubs_data
+```
+
+### 2. Install NCBI datasets CLI
+
+The backfill script requires the NCBI `datasets` command-line tool (included in
+`env.yaml` via `conda-forge::ncbi-datasets-cli`; install manually if needed).
+
+```bash
+# https://www.ncbi.nlm.nih.gov/datasets/docs/v2/download-and-install/
+datasets --version
+```
+
+## Test Suite
+
+### Quick Unit Tests
+
+Run the automated test suite with pytest:
+
+```bash
+SKIP_PREFECT=true python3 -m pytest tests/test_backfill.py -v
+```
+
+Tests cover: accession parsing, FTP version discovery, cache load/save,
+checkpoint save/resume, `parse_historical_version`, and the full backfill
+orchestrator flow.
+
+### Full Backfill Run (Small Dataset)
+
+Test the complete backfill on the 3-assembly fixture already in the repo
+(`GCA_000222935.2`, `GCA_000412225.2`, `GCA_003706615.3`):
+
+```bash
+mkdir -p /tmp/assembly-versions
+cp configs/assembly_historical.types.yaml /tmp/assembly-versions/
+
+SKIP_PREFECT=true python3 -m flows.parsers.parse_backfill_historical_versions \
+  --input_path tests/test_data/assembly_test_sample.jsonl \
+  --yaml_path /tmp/assembly-versions/assembly_historical.types.yaml \
+  --work_dir /tmp/assembly-versions
+```
+
+**PowerShell:**
+
+```powershell
+New-Item -ItemType Directory -Force -Path C:\Temp\assembly-versions
+Copy-Item configs\assembly_historical.types.yaml C:\Temp\assembly-versions\
+
+$env:SKIP_PREFECT = "true"
+python -m flows.parsers.parse_backfill_historical_versions `
+  --input_path tests\test_data\assembly_test_sample.jsonl `
+  --yaml_path C:\Temp\assembly-versions\assembly_historical.types.yaml `
+  --work_dir C:\Temp\assembly-versions
+```
+
+> **Note on output path**: the output TSV (`assembly_historical.tsv`) is written
+> relative to the *YAML file's directory*, not `--work_dir`. Copying the YAML
+> into `--work_dir` (as above) puts the output there.
+
+Requires `datasets` CLI and network access (FTP version discovery +
+`datasets summary` per version). Without them each assembly reports a clean
+per-accession failure and the run completes with 0 records written.
+
+## CLI reference
+
+```
+python3 -m flows.parsers.parse_backfill_historical_versions \
+  --input_path <assembly_data_report.jsonl>  # required
+  --yaml_path  <assembly_historical.types.yaml>  # required
+  --work_dir   <path>                            # optional, default: .
+```
+
+The run is resumable: if interrupted, re-running with the same arguments picks
+up from the last saved checkpoint in `<work_dir>/checkpoints/`.

--- a/tests/README_phase_1_daily_updates.md
+++ b/tests/README_phase_1_daily_updates.md
@@ -1,0 +1,168 @@
+# Phase 1: Daily Incremental Assembly Version Tracking
+
+This guide explains how to run and test the Phase 1 implementation: the daily
+incremental pipeline that detects assembly versions newly superseded since the
+last run and records them in `assembly_historical.tsv`.
+
+Phase 0 (one-time backfill via `parse_backfill_historical_versions.py`) must
+have run at least once before Phase 1's daily flow can detect superseded
+versions — Phase 1 reads yesterday's `assembly_current.tsv` to look up the
+previous state and compares it against today's NCBI JSONL.
+
+## Files added in Phase 1
+
+| File | Purpose |
+|---|---|
+| `flows/parsers/parse_assembly_versions.py` | Daily incremental parser — no NCBI fetches |
+| `flows/updaters/update_assembly_versions.py` | Fetches metadata for any version missing from the previous parse |
+| `flows/lib/assembly_versions_utils.py` | Shared helpers (FTP discovery, cache, accession parsing) used by both the parser and the backfill parser |
+| `configs/assembly_historical.types.yaml` | Schema/config for `assembly_historical.tsv` (added in Phase 0, referenced here) |
+
+## Prerequisites
+
+### Dependencies
+
+```bash
+conda activate genomehubs_data  # or: conda env create -f env.yaml
+```
+
+### NCBI datasets CLI
+
+Required only by the updater and the Phase 0 backfill; `parse_assembly_versions.py`
+itself makes no network calls.
+
+```bash
+# https://www.ncbi.nlm.nih.gov/datasets/docs/v2/download-and-install/
+datasets --version
+```
+
+## How the daily incremental pipeline works
+
+```
+[yesterday]  assembly_current.tsv  ──────────────────────────────────┐
+[today]      assembly_data_report.jsonl  ──► parse_assembly_versions ─┤
+                                                                       ├─► assembly_historical.tsv (updated)
+                                                                       └─► missing_versions.json (if any)
+
+missing_versions.json  ──► update_assembly_versions  ──► missing_assembly_versions.jsonl
+                                                               │
+                                                               └──► parse_backfill_historical_versions  ──► assembly_historical.tsv
+```
+
+**`parse_assembly_versions.py`** (daily, no network):
+- Reads the previous `assembly_current.tsv` (renamed `.previous` before each run)
+- Reads today's JSONL; for every assembly at version > 1 checks whether its
+  predecessor exists in the previous TSV
+- If found: copies the row and marks it `superseded`, appends to `assembly_historical.tsv`
+- If missing: writes a record to `missing_versions.json` for the updater to handle
+
+**`update_assembly_versions.py`** (runs when `missing_versions.json` exists):
+- Fetches the current accession's raw NCBI metadata for each missing entry
+- Writes `missing_assembly_versions.jsonl` — feed back into
+  `parse_backfill_historical_versions.py` (Phase 0) to complete the backfill
+
+## Minimal end-to-end walkthrough
+
+Uses `tests/test_data/assembly_test_sample.jsonl` — three real assemblies already
+in the repo (`GCA_000222935.2`, `GCA_000412225.2`, `GCA_003706615.3`), covering
+both the "predecessor found" and "predecessor missing" code paths.
+
+```bash
+mkdir -p /tmp/assembly-versions
+cp configs/assembly_historical.types.yaml /tmp/assembly-versions/
+cp tests/test_data/assembly_test_sample.jsonl /tmp/assembly-versions/assembly_data_report.jsonl
+```
+
+> **Note on output path**: `parse_backfill_historical_versions.py` writes
+> `assembly_historical.tsv` relative to the *YAML file's directory*, not
+> `--work_dir`. Copying the YAML into `--work_dir` (as above) puts the output
+> there.
+
+### Step 1 — one-time Phase 0 backfill (if not already done)
+
+```bash
+SKIP_PREFECT=true python3 -m flows.parsers.parse_backfill_historical_versions \
+  --input_path /tmp/assembly-versions/assembly_data_report.jsonl \
+  --yaml_path /tmp/assembly-versions/assembly_historical.types.yaml \
+  --work_dir /tmp/assembly-versions
+# Writes: /tmp/assembly-versions/assembly_historical.tsv
+```
+
+Requires `datasets` CLI and network (FTP version discovery + `datasets summary`).
+Without them, each assembly reports a clean per-accession fetch failure and the
+run completes with 0 records written.
+
+### Step 2 — simulate "yesterday's" parse
+
+```bash
+# Minimal previous TSV: only GCA_000222935.1 was known yesterday
+printf "accession\tassembly_id\nGCA_000222935.1\tGCA_000222935_1\n" \
+  > /tmp/assembly-versions/assembly_current.tsv.previous
+```
+
+In production this file is the `assembly_current.tsv` from the previous daily
+run, renamed before the new run writes a fresh copy.
+
+### Step 3 — run the daily incremental parser
+
+```bash
+SKIP_PREFECT=true python3 -m flows.parsers.parse_assembly_versions \
+  --input_path /tmp/assembly-versions/assembly_data_report.jsonl
+```
+
+Expected output:
+
+```
+[1/3] Loading previous parsed results...
+Loaded 1 assemblies from previous parsed results.
+
+[2/3] Identifying newly superseded versions...
+  Found: 1 newly superseded versions.
+  Examples:
+    GCA_000222935.1 -> superseded by v2
+
+  Warning: 2 assemblies have missing previous versions.
+    GCA_000412225: need v1, have v2
+    GCA_003706615: need v2, have v3
+
+[3/3] Updating historical TSV...
+  Added 1 newly superseded versions.
+
+ASSEMBLY VERSION PARSE COMPLETE  Superseded: 1  Missing: 2
+```
+
+Writes:
+- `/tmp/assembly-versions/assembly_historical.tsv` — one row appended for `GCA_000222935.1`
+- `/tmp/assembly-versions/missing_versions.json` — two entries (GCA_000412225, GCA_003706615)
+
+No network calls are made in this step.
+
+### Step 4 — fetch metadata for missing versions (requires datasets CLI)
+
+```bash
+SKIP_PREFECT=true python3 -m flows.updaters.update_assembly_versions \
+  --missing_json /tmp/assembly-versions/missing_versions.json \
+  --work_dir /tmp/assembly-versions
+# Writes: /tmp/assembly-versions/missing_assembly_versions.jsonl
+```
+
+### Step 5 — backfill the missing versions
+
+```bash
+SKIP_PREFECT=true python3 -m flows.parsers.parse_backfill_historical_versions \
+  --input_path /tmp/assembly-versions/missing_assembly_versions.jsonl \
+  --yaml_path /tmp/assembly-versions/assembly_historical.types.yaml \
+  --work_dir /tmp/assembly-versions
+# Appends the missing predecessors to assembly_historical.tsv
+```
+
+## Running the test suite
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+SKIP_PREFECT=true python3 -m pytest tests/test_assembly_versions.py -v
+```
+
+All 34 tests cover: accession parsing, path derivation, superseded-row
+building, missing-version detection, TSV append/deduplication, updater JSONL
+writing, and the `plugin()` registration hook.

--- a/tests/README_phase_2_assembly_summary.md
+++ b/tests/README_phase_2_assembly_summary.md
@@ -1,0 +1,115 @@
+# Phase 2: Assembly Version Summary
+
+This guide explains how to run and test the Phase 2 implementation:
+`generate_assembly_summary.py`, which combines `assembly_current.tsv` and
+`assembly_historical.tsv` into a per-base-accession version summary.
+
+Phase 0 (one-time backfill) and Phase 1 (daily incremental) must have run at
+least once so that both input TSVs exist before running Phase 2.
+
+## Files added in Phase 2
+
+| File | Purpose |
+|---|---|
+| `flows/lib/generate_assembly_summary.py` | Aggregates current + historical TSVs into `assembly_version_summary.tsv`; emits `generate.assembly_summary.completed` for downstream Phase 3 flows |
+
+## How it fits in the daily pipeline
+
+```
+update_ncbi_datasets          →  update.ncbi.datasets.finished
+  → fetch_parse_validate            →  validate.file.pair.finished
+    → parse_assembly_versions       →  update.assembly_versions.completed
+      → generate_assembly_summary  →  generate.assembly_summary.completed
+        → [Phase 3 taxon milestones]
+```
+
+`generate_assembly_summary` is triggered by `update.assembly_versions.completed`
+and emits `generate.assembly_summary.completed` so Phase 3 can be wired as a
+further downstream trigger.
+
+## What it produces
+
+`assembly_version_summary.tsv` — one row per base accession:
+
+| Column | Description |
+|---|---|
+| `base_accession` | Base accession without version suffix (e.g. `GCA_000002035`) |
+| `taxId` | NCBI taxonomy ID of the organism |
+| `first_version_accession` | Full accession of the earliest known version |
+| `first_version_number` | Version number of the earliest known version |
+| `first_version_date` | Release date of the earliest known version |
+| `current_version_accession` | Full accession of the latest version |
+| `current_version_number` | Version number of the latest version |
+| `current_version_date` | Release date of the latest version |
+| `total_versions` | Count of all versions (current + historical) |
+| `superseded_versions` | Count of versions with `versionStatus = superseded` |
+| `first_ebp_metric_accession` | Accession of the first version meeting EBP criteria |
+| `first_ebp_metric_version` | Version number of first EBP metric |
+| `first_ebp_metric_date` | Release date of first EBP metric |
+| `version_gaps` | Comma-separated missing version numbers, or empty |
+
+EBP metric is detected from any of: `ebpStandardDate`, `ebp_standard_date`,
+`ebpMetricDate`, `ebp_metric_date`.
+
+## Prerequisites
+
+```bash
+conda activate genomehubs_data
+```
+
+No network access or NCBI `datasets` CLI required — all inputs are local TSVs.
+
+## Running
+
+```bash
+SKIP_PREFECT=true python3 -m flows.lib.generate_assembly_summary \
+  --work_dir /tmp/assembly-versions
+```
+
+Expects in `--work_dir`:
+- `assembly_current.tsv` — written by `parse_ncbi_assemblies` (Phase 1 daily pipeline)
+- `assembly_historical.tsv` — written by Phase 0 backfill and updated by Phase 1 incremental
+
+Writes to `--work_dir`:
+- `assembly_version_summary.tsv`
+
+## Minimal end-to-end test
+
+```bash
+mkdir -p /tmp/assembly-versions
+
+# assembly_current.tsv: three assemblies, one with an EBP metric date
+cat > /tmp/assembly-versions/assembly_current.tsv << 'EOF'
+accession	releaseDate	ebpStandardDate
+GCA_000222935.2	2011-08-03	
+GCA_000412225.2	2014-06-05	2020-03-01
+GCA_003706615.3	2023-07-14	
+EOF
+
+# assembly_historical.tsv: one superseded version (Phase 0/1 output)
+cat > /tmp/assembly-versions/assembly_historical.tsv << 'EOF'
+accession	versionStatus	releaseDate	ebpStandardDate
+GCA_000222935.1	superseded	2010-01-01	
+EOF
+
+SKIP_PREFECT=true python3 -m flows.lib.generate_assembly_summary \
+  --work_dir /tmp/assembly-versions
+
+cat /tmp/assembly-versions/assembly_version_summary.tsv
+```
+
+Expected output:
+- `GCA_000222935`: 2 versions, `superseded_versions=1`, `first_version_date=2010-01-01`
+- `GCA_000412225`: 1 version, `version_gaps=1`, `first_ebp_metric_accession=GCA_000412225.2`
+- `GCA_003706615`: 1 version, `version_gaps=1,2`
+
+## Running the test suite
+
+Tests for Phase 1 (which Phase 2 builds on) are in `tests/test_assembly_versions.py`:
+
+```bash
+SKIP_PREFECT=true python3 -m pytest tests/test_assembly_versions.py -v
+```
+
+Phase 2 unit tests will be added in a follow-up once the downstream Phase 3
+taxon milestone integration is defined.

--- a/tests/README_phase_2_assembly_summary.md
+++ b/tests/README_phase_2_assembly_summary.md
@@ -1,25 +1,32 @@
 # Phase 2: Assembly Version Summary
 
-This guide explains how to run and test the Phase 2 implementation:
-`generate_assembly_summary.py`, which combines `assembly_current.tsv` and
-`assembly_historical.tsv` into a per-base-accession version summary.
+This guide covers the Phase 2 implementation, which has two parts:
+
+- **Phase 2.1 — previous-current snapshot** (`parse_ncbi_assemblies.py`): preserves
+  yesterday's `assembly_current.tsv` as `assembly_current.tsv.previous` before today's
+  parse overwrites it, so the Phase 1 incremental can find each superseded predecessor.
+- **Phase 2.2 — assembly version summary** (`generate_assembly_summary.py`): combines
+  `assembly_current.tsv` and `assembly_historical.tsv` into a per-base-accession version
+  summary.
 
 Phase 0 (one-time backfill) and Phase 1 (daily incremental) must have run at
-least once so that both input TSVs exist before running Phase 2.
+least once so that both input TSVs exist before running Phase 2.2.
 
-## Files added in Phase 2
+## Files added/changed in Phase 2
 
-| File | Purpose |
-|---|---|
-| `flows/lib/generate_assembly_summary.py` | Aggregates current + historical TSVs into `assembly_version_summary.tsv`; emits `generate.assembly_summary.completed` for downstream Phase 3 flows |
+| File | Phase | Purpose |
+|---|---|---|
+| `flows/parsers/parse_ncbi_assemblies.py` | 2.1 | Adds `snapshot_previous_output`, called just before `write_to_tsv`, to copy the prior `assembly_current.tsv` → `assembly_current.tsv.previous` before the overwrite |
+| `flows/lib/generate_assembly_summary.py` | 2.2 | Aggregates current + historical TSVs into `assembly_version_summary.tsv`; emits `generate.assembly_summary.completed` for downstream Phase 3 flows |
 
 ## How it fits in the daily pipeline
 
 ```
 update_ncbi_datasets          →  update.ncbi.datasets.finished
   → fetch_parse_validate            →  validate.file.pair.finished
+      (parse_ncbi_assemblies: snapshot .previous, then write assembly_current.tsv)   [2.1]
     → parse_assembly_versions       →  update.assembly_versions.completed
-      → generate_assembly_summary  →  generate.assembly_summary.completed
+      → generate_assembly_summary  →  generate.assembly_summary.completed            [2.2]
         → [Phase 3 taxon milestones]
 ```
 
@@ -27,7 +34,29 @@ update_ncbi_datasets          →  update.ncbi.datasets.finished
 and emits `generate.assembly_summary.completed` so Phase 3 can be wired as a
 further downstream trigger.
 
-## What it produces
+## Phase 2.1: previous-current snapshot
+
+`parse_assembly_versions` (Phase 1 daily incremental) needs **yesterday's** full
+current set to find each newly superseded predecessor (`v_n-1`). But
+`parse_ncbi_assemblies` overwrites `assembly_current.tsv` **in place** with today's
+parse, so without intervention yesterday's copy is lost before the incremental runs.
+
+`snapshot_previous_output(config)` closes that gap: immediately before `write_to_tsv`,
+it copies `config.meta["file_name"]` → `<same>.previous`. At that point
+`fetch_previous_file_pair` has already placed yesterday's published
+`assembly_current.tsv` on disk, so the snapshot captures yesterday's copy at exactly
+`<work_dir>/assembly_current.tsv.previous` — the path `parse_assembly_versions` reads.
+It is a no-op on the first run, when no prior output exists.
+
+This is a *different* mechanism from how `parse_ncbi_assemblies` reuses prior results
+(`fetch_previous_file_pair` / `Config.load_previous`), which reads the prior run's TSV
+under its **plain** name to copy over unchanged rows.
+
+**Ordering constraint:** the current parse and the historical parse must run in the
+**same `work_dir`**, current first, so the `.previous` snapshot is visible to the
+incremental step. The existing pipeline already satisfies this.
+
+## Phase 2.2: what it produces
 
 `assembly_version_summary.tsv` — one row per base accession:
 
@@ -81,15 +110,15 @@ mkdir -p /tmp/assembly-versions
 # assembly_current.tsv: three assemblies, one with an EBP metric date
 cat > /tmp/assembly-versions/assembly_current.tsv << 'EOF'
 accession	releaseDate	ebpStandardDate
-GCA_000222935.2	2011-08-03	
+GCA_000222935.2	2011-08-03
 GCA_000412225.2	2014-06-05	2020-03-01
-GCA_003706615.3	2023-07-14	
+GCA_003706615.3	2023-07-14
 EOF
 
 # assembly_historical.tsv: one superseded version (Phase 0/1 output)
 cat > /tmp/assembly-versions/assembly_historical.tsv << 'EOF'
 accession	versionStatus	releaseDate	ebpStandardDate
-GCA_000222935.1	superseded	2010-01-01	
+GCA_000222935.1	superseded	2010-01-01
 EOF
 
 SKIP_PREFECT=true python3 -m flows.lib.generate_assembly_summary \
@@ -105,11 +134,16 @@ Expected output:
 
 ## Running the test suite
 
-Tests for Phase 1 (which Phase 2 builds on) are in `tests/test_assembly_versions.py`:
+Phase 1 tests (which Phase 2 builds on) and the Phase 2.1 snapshot tests both live in
+`tests/test_assembly_versions.py`:
 
 ```bash
 SKIP_PREFECT=true python3 -m pytest tests/test_assembly_versions.py -v
 ```
 
-Phase 2 unit tests will be added in a follow-up once the downstream Phase 3
-taxon milestone integration is defined.
+- **Phase 2.1** — `TestSnapshotPreviousOutput` covers: `.previous` created with
+  identical content, no-op when no prior output exists, no-op when `file_name` is
+  missing, and overwrite of a stale `.previous`.
+- **Phase 2.2** — `generate_assembly_summary` unit tests will be added in a follow-up
+  once the downstream Phase 3 taxon milestone integration is defined; for now, validate
+  it with the minimal end-to-end test above.

--- a/tests/test_assembly_versions.py
+++ b/tests/test_assembly_versions.py
@@ -33,6 +33,7 @@ from flows.parsers.parse_assembly_versions import (  # noqa: E402
     load_previous_parsed_by_base,
     parse_assembly_versions,
 )
+from flows.parsers.parse_ncbi_assemblies import snapshot_previous_output  # noqa: E402
 from flows.updaters import update_assembly_versions as updater_module  # noqa: E402
 from flows.updaters.update_assembly_versions import (  # noqa: E402
     load_missing_versions,
@@ -509,3 +510,56 @@ class TestParseAssemblyVersionsPlugin:
         path.write_text(json.dumps(entries))
         result = load_missing_versions(str(path))
         assert result == entries
+
+
+# ---------------------------------------------------------------------------
+# TestSnapshotPreviousOutput
+# ---------------------------------------------------------------------------
+
+class TestSnapshotPreviousOutput:
+    """snapshot_previous_output preserves yesterday's output before it is overwritten.
+
+    parse_assembly_versions reads assembly_current.tsv.previous to find each newly
+    superseded predecessor; the snapshot must be taken before parse_ncbi_assemblies
+    overwrites assembly_current.tsv in place.
+    """
+
+    @staticmethod
+    def _config(file_name) -> MagicMock:
+        """Build a stand-in Config exposing only meta['file_name']."""
+        config = MagicMock()
+        config.meta = {"file_name": str(file_name)}
+        return config
+
+    def test_creates_previous_with_identical_content(self, tmp_path):
+        output = tmp_path / "assembly_current.tsv"
+        write_tsv(output, [{"accession": "GCA_000002035.3", "releaseDate": "2020-01-01"}])
+
+        snapshot_previous_output(self._config(output))
+
+        previous = tmp_path / "assembly_current.tsv.previous"
+        assert previous.exists()
+        assert previous.read_bytes() == output.read_bytes()
+
+    def test_no_op_when_no_prior_output(self, tmp_path):
+        output = tmp_path / "assembly_current.tsv"  # never created
+
+        snapshot_previous_output(self._config(output))
+
+        assert not (tmp_path / "assembly_current.tsv.previous").exists()
+
+    def test_no_op_when_file_name_missing(self):
+        config = MagicMock()
+        config.meta = {}  # no file_name key
+        # Should not raise.
+        snapshot_previous_output(config)
+
+    def test_overwrites_stale_previous_snapshot(self, tmp_path):
+        output = tmp_path / "assembly_current.tsv"
+        previous = tmp_path / "assembly_current.tsv.previous"
+        previous.write_text("stale-from-an-earlier-run\n", encoding="utf-8")
+        write_tsv(output, [{"accession": "GCA_000002035.4", "releaseDate": "2021-06-01"}])
+
+        snapshot_previous_output(self._config(output))
+
+        assert previous.read_bytes() == output.read_bytes()


### PR DESCRIPTION
## Phase 2 — assembly version tracking

This PR covers two Phase 2 pieces of the version-aware assembly pipeline.

### Phase 2.1 — snapshot previous `assembly_current.tsv` (`parse_ncbi_assemblies.py`)
`parse_assembly_versions` (Phase 1.1) needs **yesterday's** full current set to find
each newly superseded predecessor (`v_n-1`), but `parse_ncbi_assemblies` overwrites
`assembly_current.tsv` in place. This adds `snapshot_previous_output`, which copies the
prior output to `assembly_current.tsv.previous` immediately before the overwrite — at
the exact path the historical parser reads. No-op on the first run.

- Depends on the current parse and historical parse running in the **same `work_dir`**,
  current first (already assumed by the existing design).
- Regression tests in `tests/test_assembly_versions.py` (`TestSnapshotPreviousOutput`).

### Phase 2.2 — assembly version summary (`generate_assembly_summary.py`)
Combines `assembly_current.tsv` + `assembly_historical.tsv` into a per-base-accession
`assembly_version_summary.tsv` (first/current version dates, EBP metric tracking,
version gaps, `taxId`). Emits `generate.assembly_summary.completed`.

### Tests
`tests/test_assembly_versions.py` — 38 passed.